### PR TITLE
Update cloud_install.html

### DIFF
--- a/www/devzone/book/cloud_install.html
+++ b/www/devzone/book/cloud_install.html
@@ -54,11 +54,11 @@ sudo apt-get install -y cassandra=2.0.7</div>
 <p>
     Run:
 </p>
-<div class=code>sudo apt-get install -y python-software-properties
+<div class=code>sudo apt-get install software-properties-common python-software-properties
 sudo add-apt-repository ppa:webupd8team/java</div>
 
 <p>
-    Press ENTER when prompted.  The run:
+    Press ENTER when prompted.  Then run:
 </p>
 <div class=code>sudo apt-get update
 sudo apt-get install -y oracle-java7-installer</div>


### PR DESCRIPTION
avoid the " add-apt-repository: command not found" error when install canopy server
